### PR TITLE
Exposed cluster.routing.allocation.enable setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This plugin was started as a fork of the Prometheus exporter for Elasticsearch®
     - File System
     - Circuit Breaker
 - Indices status
-- Cluster settings (notably [disk watermarks](https://docs.opensearch.org/latest/install-and-configure/configuring-opensearch/cluster-settings/#cluster-level-routing-and-allocation-settings) that can be updated dynamically)
+- Cluster settings (notably [disk watermarks](https://docs.opensearch.org/latest/install-and-configure/configuring-opensearch/cluster-settings/#cluster-level-routing-and-allocation-settings) that can be updated dynamically, and the shard routing allocation mode `cluster.routing.allocation.enable` exposed as `opensearch_cluster_routing_allocation_enabled` with values `0=all`, `1=primaries`, `2=new_primaries`, `3=none`)
 
 ## Compatibility Matrix
 

--- a/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java
+++ b/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java
@@ -902,6 +902,9 @@ public class PrometheusMetricsCollector {
         catalog.registerClusterGauge("cluster_routing_allocation_disk_watermark_low_pct", "Low watermark for disk usage in pct");
         catalog.registerClusterGauge("cluster_routing_allocation_disk_watermark_high_pct", "High watermark for disk usage in pct");
         catalog.registerClusterGauge("cluster_routing_allocation_disk_watermark_flood_stage_pct", "Flood stage watermark for disk usage in pct");
+        //
+        catalog.registerClusterGauge("cluster_routing_allocation_enabled",
+                "Cluster shard routing allocation mode (0=all, 1=primaries, 2=new_primaries, 3=none)");
     }
 
     @SuppressWarnings({"checkstyle:LineLength", "checkstyle:LeftCurly"})
@@ -919,6 +922,9 @@ public class PrometheusMetricsCollector {
             if (stats.getDiskLowInPct() != null) { catalog.setClusterGauge("cluster_routing_allocation_disk_watermark_low_pct", stats.getDiskLowInPct()); }
             if (stats.getDiskHighInPct() != null) { catalog.setClusterGauge("cluster_routing_allocation_disk_watermark_high_pct", stats.getDiskHighInPct()); }
             if (stats.getFloodStageInPct() != null) { catalog.setClusterGauge("cluster_routing_allocation_disk_watermark_flood_stage_pct", stats.getFloodStageInPct()); }
+            // Default to 0 (all) when unset, matching OpenSearch's default and the ES exporter output.
+            Integer shardAllocation = stats.getShardAllocation();
+            catalog.setClusterGauge("cluster_routing_allocation_enabled", shardAllocation != null ? shardAllocation : 0);
         }
     }
 

--- a/src/main/java/org/opensearch/action/ClusterStatsData.java
+++ b/src/main/java/org/opensearch/action/ClusterStatsData.java
@@ -20,6 +20,7 @@ import static org.opensearch.cluster.routing.allocation.DiskThresholdSettings.CL
 import static org.opensearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING;
 import static org.opensearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING;
 import static org.opensearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING;
+import static org.opensearch.cluster.routing.allocation.decider.EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE_SETTING;
 
 import org.opensearch.OpenSearchParseException;
 import org.opensearch.action.admin.cluster.state.ClusterStateResponse;
@@ -34,6 +35,7 @@ import org.opensearch.common.settings.SettingsException;
 import org.opensearch.common.unit.RatioValue;
 
 import java.io.IOException;
+import java.util.Locale;
 
 
 /**
@@ -64,6 +66,9 @@ public class ClusterStatsData extends ActionResponse {
     @Nullable private final Double diskHighInPct;
     @Nullable private final Double floodStageInPct;
 
+    // Encodes cluster.routing.allocation.enable as: 0=all, 1=primaries, 2=new_primaries, 3=none
+    @Nullable private final Integer shardAllocation;
+
     /**
      * A constructor.
      * @param in A {@link StreamInput} to materialize the instance from
@@ -80,6 +85,8 @@ public class ClusterStatsData extends ActionResponse {
         diskLowInPct = in.readOptionalDouble();
         diskHighInPct = in.readOptionalDouble();
         floodStageInPct = in.readOptionalDouble();
+        //
+        shardAllocation = in.readOptionalInt();
     }
 
     @SuppressWarnings({"checkstyle:LineLength"})
@@ -94,6 +101,7 @@ public class ClusterStatsData extends ActionResponse {
         Double resolvedDiskLowInPct = null;
         Double resolvedDiskHighInPct = null;
         Double resolvedFloodStageInPct = null;
+        Integer resolvedShardAllocation = null;
 
         // There are several layers of cluster settings in OpenSearch each having different priority.
         // We need to traverse them from the top priority down to find relevant value of each setting.
@@ -106,6 +114,13 @@ public class ClusterStatsData extends ActionResponse {
             if (resolvedThresholdEnabled == null) {
                 resolvedThresholdEnabled = currentSettings.getAsBoolean(
                         CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey(), null);
+            }
+
+            if (resolvedShardAllocation == null) {
+                String allocationValue = currentSettings.get(CLUSTER_ROUTING_ALLOCATION_ENABLE_SETTING.getKey());
+                if (allocationValue != null) {
+                    resolvedShardAllocation = mapShardAllocation(allocationValue);
+                }
             }
 
             LongValue parsedLow = parseWatermarkValue(
@@ -134,6 +149,25 @@ public class ClusterStatsData extends ActionResponse {
         diskLowInPct = resolvedDiskLowInPct;
         diskHighInPct = resolvedDiskHighInPct;
         floodStageInPct = resolvedFloodStageInPct;
+        shardAllocation = resolvedShardAllocation;
+    }
+
+    /**
+     * Map the string value of {@code cluster.routing.allocation.enable} to the numeric encoding
+     * used by the Elasticsearch exporter: all=0, primaries=1, new_primaries=2, none=3.
+     * Returns {@code null} for any unrecognized value.
+     * @param value The raw setting value.
+     * @return The numeric encoding, or {@code null} if not recognized.
+     */
+    @Nullable
+    private static Integer mapShardAllocation(String value) {
+        switch (value.toLowerCase(Locale.ROOT)) {
+            case "all":           return 0;
+            case "primaries":     return 1;
+            case "new_primaries": return 2;
+            case "none":          return 3;
+            default:              return null;
+        }
     }
 
     private record LongValue(@Nullable Long bytes, @Nullable Double pct) {
@@ -177,6 +211,8 @@ public class ClusterStatsData extends ActionResponse {
         out.writeOptionalDouble(diskLowInPct);
         out.writeOptionalDouble(diskHighInPct);
         out.writeOptionalDouble(floodStageInPct);
+        //
+        out.writeOptionalInt(shardAllocation);
     }
 
     /**
@@ -240,5 +276,15 @@ public class ClusterStatsData extends ActionResponse {
     @Nullable
     public Double getFloodStageInPct() {
         return floodStageInPct;
+    }
+
+    /**
+     * Get the numeric encoding of {@code cluster.routing.allocation.enable}
+     * (0=all, 1=primaries, 2=new_primaries, 3=none), or {@code null} if unset/unrecognized.
+     * @return An Integer value of the setting.
+     */
+    @Nullable
+    public Integer getShardAllocation() {
+        return shardAllocation;
     }
 }

--- a/src/yamlRestTest/resources/rest-api-spec/test/40_40_cluster_settings_shard_allocation.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/40_40_cluster_settings_shard_allocation.yml
@@ -1,0 +1,125 @@
+---
+"Cluster settings statistics: shard allocation enable":
+
+  # -----------------------------------
+  # By default "cluster.routing.allocation.enable" is "all", which we encode as 0.
+  # OOTB there are no transient or persistent settings in the cluster:
+  - do:
+      cluster.get_settings:
+        flat_settings: true
+
+  - match: {persistent: {}}
+  - match: {transient: {}}
+
+  # Default (all) -> 0.0
+  - do:
+      prometheus.metrics: {}
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s opensearch_cluster_routing_allocation_enabled (\s|\w|\d|\(|\)|\,|\=)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_enabled \s gauge \n
+        opensearch_cluster_routing_allocation_enabled\{
+            cluster="yamlRestTest"
+        \,} \s 0\.0 \n?
+        .*/
+
+  # -----------------------------------
+  # Set to "none" at the PERSISTENT level -> 3.0
+  - do:
+      cluster.put_settings:
+        body:
+          persistent:
+            cluster.routing.allocation.enable: none
+        flat_settings: true
+
+  - match: {persistent: {cluster.routing.allocation.enable: "none"}}
+
+  - do:
+      prometheus.metrics: {}
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s opensearch_cluster_routing_allocation_enabled (\s|\w|\d|\(|\)|\,|\=)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_enabled \s gauge \n
+        opensearch_cluster_routing_allocation_enabled\{
+            cluster="yamlRestTest"
+        \,} \s 3\.0 \n?
+        .*/
+
+  # -----------------------------------
+  # Set "primaries" at the TRANSIENT level; transient overrides persistent -> 1.0
+  - do:
+      cluster.put_settings:
+        body:
+          transient:
+            cluster.routing.allocation.enable: primaries
+        flat_settings: true
+
+  - match: {transient: {cluster.routing.allocation.enable: "primaries"}}
+
+  - do:
+      prometheus.metrics: {}
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s opensearch_cluster_routing_allocation_enabled (\s|\w|\d|\(|\)|\,|\=)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_enabled \s gauge \n
+        opensearch_cluster_routing_allocation_enabled\{
+            cluster="yamlRestTest"
+        \,} \s 1\.0 \n?
+        .*/
+
+  # -----------------------------------
+  # Change transient to "new_primaries" -> 2.0
+  - do:
+      cluster.put_settings:
+        body:
+          transient:
+            cluster.routing.allocation.enable: new_primaries
+        flat_settings: true
+
+  - match: {transient: {cluster.routing.allocation.enable: "new_primaries"}}
+
+  - do:
+      prometheus.metrics: {}
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s opensearch_cluster_routing_allocation_enabled (\s|\w|\d|\(|\)|\,|\=)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_enabled \s gauge \n
+        opensearch_cluster_routing_allocation_enabled\{
+            cluster="yamlRestTest"
+        \,} \s 2\.0 \n?
+        .*/
+
+  # -----------------------------------
+  # Clean up cluster state; back to default (all) -> 0.0
+  - do:
+      cluster.put_settings:
+        body:
+          transient:
+            cluster.routing.allocation.enable: null
+          persistent:
+            cluster.routing.allocation.enable: null
+        flat_settings: true
+
+  - match: {transient: {}}
+  - match: {persistent: {}}
+
+  - do:
+      prometheus.metrics: {}
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s opensearch_cluster_routing_allocation_enabled (\s|\w|\d|\(|\)|\,|\=)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_enabled \s gauge \n
+        opensearch_cluster_routing_allocation_enabled\{
+            cluster="yamlRestTest"
+        \,} \s 0\.0 \n?
+        .*/


### PR DESCRIPTION
### Description
This change adds support for exporting the cluster setting `cluster.routing.allocation.enable` as a Prometheus gauge metric: `opensearch_cluster_routing_allocation_enabled`.
The metric value is encoded for Elasticsearch exporter parity:
- `0 = all`
- `1 = primaries`
- `2 = new_primaries`
- `3 = none`
Implementation updates include:
- Parsing and resolving the setting in `ClusterStatsData` (including serialization support).
- Registering and publishing the new gauge in `PrometheusMetricsCollector` (defaulting to `0` when unset).
- Adding YAML REST coverage for default, persistent, transient-overrides-persistent, and cleanup scenarios.
- Updating `README.md` with metric details.

### Related Issues
Resolves #514  
Related: #505

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-prometheus-exporter/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).