### PR TITLE
Remove stale version comments after pinned GH Actions hashes

### DIFF
--- a/.github/workflows/BWC.yml
+++ b/.github/workflows/BWC.yml
@@ -20,9 +20,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a
         with:
           distribution: "temurin"
           java-version: ${{ matrix.java }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,9 +23,9 @@ jobs:
     steps:
       - name: Run start commands
         run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a
         with:
           distribution: "temurin"
           java-version: ${{ matrix.java }}
@@ -34,7 +34,7 @@ jobs:
           chown -R 1000:1000 `pwd`
           su `id -un 1000` -c "./gradlew --info build"
       - name: Upload coverage
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Create Artifact Path
@@ -43,7 +43,7 @@ jobs:
           cp -r ./build/distributions/*.zip prometheus-exporter-builds/
           chown -R 1000:1000 `pwd`
       - name: Upload Artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: prometheus-exporter-linux-${{ matrix.java }}
           path: prometheus-exporter-builds

--- a/.github/workflows/add-untriaged.yml
+++ b/.github/workflows/add-untriaged.yml
@@ -11,7 +11,7 @@ jobs:
   apply-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
           script: |
             github.rest.issues.addLabels({

--- a/.github/workflows/code-hygiene.yml
+++ b/.github/workflows/code-hygiene.yml
@@ -8,15 +8,15 @@ jobs:
     runs-on: ubuntu-latest
     name: Checkstyle scan
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
-      - uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
+      - uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a
         with:
           distribution: "temurin"
           java-version: 21
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92
         with:
           cache-disabled: true
 

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: lychee Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # master


### PR DESCRIPTION
## Summary
- Removes the trailing `# vN` version comments that follow pinned (hashed) GitHub Actions references in `.github/workflows/*.yml`.
- Dependabot updates the pinned SHA when it bumps an action, but it does not update the trailing version comment, so these comments silently drift out of sync with the actual pinned version (see #565, where `actions/setup-java` was bumped from 5.4.0 to 5.5.0 but the comment still said `v5`).
- Left `lycheeverse/lychee-action@... # master` untouched since `master` is a branch reference, not a version number, and is out of scope for this issue.

## Files changed
- `.github/workflows/add-untriaged.yml`
- `.github/workflows/BWC.yml`
- `.github/workflows/CI.yml`
- `.github/workflows/code-hygiene.yml`
- `.github/workflows/link-checker.yml`

## Test plan
- [x] Verified no `uses: ...@<hash> # vN` patterns remain in `.github/workflows/`
- [x] Diff only removes comments; no functional/hash changes to any action reference

Fixes #566