### PR TITLE
Bound the stats fan-out with a per-step timeout, degrade gracefully on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,18 @@ To disable exporting cluster settings use:
 prometheus.cluster.settings: false
 ```
 
+#### Scrape step timeout
+
+Per-step timeout applied to each individual request the exporter makes while gathering a scrape
+(nodes stats, indices stats). Without a bound, a single non-responding node (for example one stuck
+in D-state under a disk failure) can stall the whole scrape indefinitely, since these requests fan
+out to every node in the cluster. When a step times out, the exporter returns partial metrics for
+that step instead of failing the whole scrape. Default value: `5s`.
+
+```
+prometheus.scrape.step_timeout: "5s"
+```
+
 #### Nodes filter
 
 Metrics include statistics about individual OpenSearch nodes.

--- a/build.gradle
+++ b/build.gradle
@@ -126,6 +126,13 @@ dependencies {
     implementation group: 'io.prometheus', name: 'simpleclient', version: '0.16.0'
     implementation group: 'io.prometheus', name: 'simpleclient_common', version: '0.16.0'
     zipArchive group: 'org.opensearch.plugin.prometheus', name:'prometheus-exporter', version: "${versions.opensearch}"
+
+    def mockitoVersion = '5.23.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.2'
+    testImplementation "org.mockito:mockito-core:${mockitoVersion}"
+    testImplementation "org.mockito:mockito-junit-jupiter:${mockitoVersion}"
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.2'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 restResources {
@@ -135,6 +142,7 @@ restResources {
 }
 
 test {
+    useJUnitPlatform()
     include '**/*Tests.class'
 }
 

--- a/src/main/java/org/compuscene/metrics/prometheus/PrometheusSettings.java
+++ b/src/main/java/org/compuscene/metrics/prometheus/PrometheusSettings.java
@@ -22,6 +22,7 @@ import org.opensearch.core.common.Strings;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 
 /**
  * Dynamically updatable Prometheus exporter settings.
@@ -67,6 +68,7 @@ public class PrometheusSettings {
     static String PROMETHEUS_NODES_FILTER_KEY = "prometheus.nodes.filter";
     static String PROMETHEUS_SELECTED_INDICES_KEY = "prometheus.indices_filter.selected_indices";
     static String PROMETHEUS_SELECTED_OPTION_KEY = "prometheus.indices_filter.selected_option";
+    static String PROMETHEUS_SCRAPE_STEP_TIMEOUT_KEY = "prometheus.scrape.step_timeout";
 
     /**
      * This setting is used configure weather to expose cluster settings metrics or not. The default value is true.
@@ -112,11 +114,23 @@ public class PrometheusSettings {
                     String.valueOf(INDEX_FILTER_OPTIONS.STRICT_EXPAND_OPEN_FORBID_CLOSED),
                     INDEX_FILTER_OPTIONS::valueOf, Setting.Property.Dynamic, Setting.Property.NodeScope);
 
+    /**
+     * Per-step timeout applied to each individual request the exporter makes while gathering a
+     * scrape (nodes stats, indices stats). Without a bound, a single non-responding node (e.g. one
+     * stuck in D-state under disk failure) can stall the whole scrape indefinitely, since these
+     * requests fan out to every node in the cluster. The default value is 5 seconds.
+     * Can be configured in opensearch.yml file or updated dynamically under key {@link #PROMETHEUS_SCRAPE_STEP_TIMEOUT_KEY}.
+     */
+    public static final Setting<TimeValue> PROMETHEUS_SCRAPE_STEP_TIMEOUT =
+            Setting.positiveTimeSetting(PROMETHEUS_SCRAPE_STEP_TIMEOUT_KEY, TimeValue.timeValueSeconds(5),
+                    Setting.Property.Dynamic, Setting.Property.NodeScope);
+
     private volatile boolean clusterSettings;
     private volatile boolean indices;
     private volatile String nodesFilter;
     private volatile String selectedIndices;
     private volatile INDEX_FILTER_OPTIONS selectedOption;
+    private volatile TimeValue scrapeStepTimeout;
 
     /**
      * A constructor.
@@ -129,11 +143,13 @@ public class PrometheusSettings {
         setPrometheusNodesFilter(PROMETHEUS_NODES_FILTER.get(settings));
         setPrometheusSelectedIndices(PROMETHEUS_SELECTED_INDICES.get(settings));
         setPrometheusSelectedOption(PROMETHEUS_SELECTED_OPTION.get(settings));
+        setScrapeStepTimeout(PROMETHEUS_SCRAPE_STEP_TIMEOUT.get(settings));
         clusterSettings.addSettingsUpdateConsumer(PROMETHEUS_CLUSTER_SETTINGS, this::setPrometheusClusterSettings);
         clusterSettings.addSettingsUpdateConsumer(PROMETHEUS_INDICES, this::setPrometheusIndices);
         clusterSettings.addSettingsUpdateConsumer(PROMETHEUS_NODES_FILTER, this::setPrometheusNodesFilter);
         clusterSettings.addSettingsUpdateConsumer(PROMETHEUS_SELECTED_INDICES, this::setPrometheusSelectedIndices);
         clusterSettings.addSettingsUpdateConsumer(PROMETHEUS_SELECTED_OPTION, this::setPrometheusSelectedOption);
+        clusterSettings.addSettingsUpdateConsumer(PROMETHEUS_SCRAPE_STEP_TIMEOUT, this::setScrapeStepTimeout);
     }
 
     private void setPrometheusClusterSettings(boolean flag) {
@@ -152,6 +168,10 @@ public class PrometheusSettings {
 
     private void setPrometheusSelectedOption(INDEX_FILTER_OPTIONS selectedOption) {
         this.selectedOption = selectedOption;
+    }
+
+    private void setScrapeStepTimeout(TimeValue timeout) {
+        this.scrapeStepTimeout = timeout;
     }
 
     /**
@@ -182,6 +202,14 @@ public class PrometheusSettings {
      */
     public String[] getPrometheusSelectedIndices() {
         return Strings.splitStringByCommaToArray(this.selectedIndices);
+    }
+
+    /**
+     * Get value of settings key {@link #PROMETHEUS_SCRAPE_STEP_TIMEOUT_KEY}.
+     * @return TimeValue of the key
+     */
+    public TimeValue getScrapeStepTimeout() {
+        return this.scrapeStepTimeout;
     }
 
     /**

--- a/src/main/java/org/opensearch/action/TransportNodePrometheusMetricsAction.java
+++ b/src/main/java/org/opensearch/action/TransportNodePrometheusMetricsAction.java
@@ -40,6 +40,7 @@ import org.opensearch.common.Nullable;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
@@ -105,6 +106,7 @@ public class TransportNodePrometheusMetricsAction extends HandledTransportAction
         private final boolean isPrometheusIndices = prometheusSettings.getPrometheusIndices();
         private final boolean isPrometheusClusterSettings = prometheusSettings.getPrometheusClusterSettings();
         private final String prometheusNodesFilter = prometheusSettings.getNodesFilter();
+        private final TimeValue stepTimeout = prometheusSettings.getScrapeStepTimeout();
 
         // All the requests are executed in sequential non-blocking order.
         // It is implemented by wrapping each individual request with ActionListener
@@ -127,6 +129,12 @@ public class TransportNodePrometheusMetricsAction extends HandledTransportAction
             this.localNodesInfoRequest = Requests.nodesInfoRequest("_local").clear();
 
             this.nodesStatsRequest = Requests.nodesStatsRequest(prometheusNodesFilter).clear().all();
+            // NodesStatsRequest scatters to every targeted node via TransportNodesAction. Without an explicit
+            // timeout, a single non-responding node (e.g. stuck in D-state) can stall this step indefinitely,
+            // which stalls the entire scrape chain. With timeout() set, a non-responding node's slot resolves
+            // as a per-node failure once the deadline passes, and onResponse() still fires with results from
+            // the nodes that did respond.
+            this.nodesStatsRequest.timeout(stepTimeout);
 
             // Indices stats request is not "node-specific", it does not support any "_local" notion
             // it is broad-casted to all cluster nodes.
@@ -134,6 +142,13 @@ public class TransportNodePrometheusMetricsAction extends HandledTransportAction
                 IndicesStatsRequest indicesStatsRequest = new IndicesStatsRequest();
                 indicesStatsRequest.indices(prometheusSettings.getPrometheusSelectedIndices());
                 indicesStatsRequest.indicesOptions(prometheusSettings.getIndicesOptions());
+                // IndicesStatsRequest broadcasts to all data nodes via TransportBroadcastByNodeAction.
+                // timeout() sets a per-node deadline via TransportRequestOptions; setShouldCancelOnTimeout(true)
+                // actively cancels child tasks on a stuck node when the deadline fires. When a node times out,
+                // its failure is stored in the response array and onResponse() still fires with partial results
+                // from the nodes that did respond.
+                indicesStatsRequest.timeout(stepTimeout);
+                indicesStatsRequest.setShouldCancelOnTimeout(true);
                 this.indicesStatsRequest = indicesStatsRequest;
             } else {
                 this.indicesStatsRequest = null;

--- a/src/main/java/org/opensearch/plugin/prometheus/PrometheusExporterPlugin.java
+++ b/src/main/java/org/opensearch/plugin/prometheus/PrometheusExporterPlugin.java
@@ -82,6 +82,7 @@ public class PrometheusExporterPlugin extends Plugin implements ActionPlugin {
                 PrometheusSettings.PROMETHEUS_NODES_FILTER,
                 PrometheusSettings.PROMETHEUS_SELECTED_INDICES,
                 PrometheusSettings.PROMETHEUS_SELECTED_OPTION,
+                PrometheusSettings.PROMETHEUS_SCRAPE_STEP_TIMEOUT,
                 RestPrometheusMetricsAction.METRIC_PREFIX
         );
         return Collections.unmodifiableList(settings);

--- a/src/test/java/org/opensearch/action/TransportNodePrometheusMetricsActionTests.java
+++ b/src/test/java/org/opensearch/action/TransportNodePrometheusMetricsActionTests.java
@@ -1,0 +1,228 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action;
+
+import org.compuscene.metrics.prometheus.PrometheusSettings;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.opensearch.action.admin.cluster.node.info.NodesInfoResponse;
+import org.opensearch.action.admin.cluster.node.stats.NodesStatsRequest;
+import org.opensearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.opensearch.action.admin.indices.stats.IndicesStatsRequest;
+import org.opensearch.action.admin.indices.stats.IndicesStatsResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.AdminClient;
+import org.opensearch.transport.client.Client;
+import org.opensearch.transport.client.ClusterAdminClient;
+import org.opensearch.transport.client.IndicesAdminClient;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the per-step timeout / non-fatal degrade behavior of
+ * {@link TransportNodePrometheusMetricsAction}. These cover the resilience fix only: a stuck
+ * node responding to the NodesStats or IndicesStats fan-out must not fail the whole scrape.
+ */
+class TransportNodePrometheusMetricsActionTests {
+
+    @Mock private Client client;
+    @Mock private AdminClient adminClient;
+    @Mock private ClusterAdminClient clusterAdminClient;
+    @Mock private IndicesAdminClient indicesAdminClient;
+    @Mock private TransportService transportService;
+    @Mock private ActionFilters actionFilters;
+    @Mock private Task task;
+
+    private ClusterSettings clusterSettings;
+
+    private static Set<Setting<?>> allSettings() {
+        Set<Setting<?>> settings = new HashSet<>();
+        settings.add(PrometheusSettings.PROMETHEUS_CLUSTER_SETTINGS);
+        settings.add(PrometheusSettings.PROMETHEUS_INDICES);
+        settings.add(PrometheusSettings.PROMETHEUS_NODES_FILTER);
+        settings.add(PrometheusSettings.PROMETHEUS_SELECTED_INDICES);
+        settings.add(PrometheusSettings.PROMETHEUS_SELECTED_OPTION);
+        settings.add(PrometheusSettings.PROMETHEUS_SCRAPE_STEP_TIMEOUT);
+        return settings;
+    }
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        when(client.admin()).thenReturn(adminClient);
+        when(adminClient.cluster()).thenReturn(clusterAdminClient);
+        lenient().when(adminClient.indices()).thenReturn(indicesAdminClient);
+    }
+
+    private TransportNodePrometheusMetricsAction createAction(Settings settings) {
+        clusterSettings = new ClusterSettings(settings, allSettings());
+        return new TransportNodePrometheusMetricsAction(
+            settings, client, transportService, actionFilters, clusterSettings
+        );
+    }
+
+    private void completeClusterHealthAndNodesInfo() {
+        ArgumentCaptor<ActionListener<ClusterHealthResponse>> healthCaptor = ArgumentCaptor.forClass(ActionListener.class);
+        verify(clusterAdminClient).health(any(), healthCaptor.capture());
+        healthCaptor.getValue().onResponse(mock(ClusterHealthResponse.class));
+
+        ArgumentCaptor<ActionListener<NodesInfoResponse>> infoCaptor = ArgumentCaptor.forClass(ActionListener.class);
+        verify(clusterAdminClient).nodesInfo(any(), infoCaptor.capture());
+        infoCaptor.getValue().onResponse(mock(NodesInfoResponse.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void indicesStatsTotalFailure_propagatesAsFailure() {
+        // A total IndicesStats failure (e.g. index_not_found_exception from a misconfigured indices filter,
+        // raised during index resolution before the broadcast) must surface to the caller, not be silently
+        // swallowed into a 200 with partial metrics. A single stuck node is handled separately by the
+        // per-node request timeout, which yields partial results via onResponse rather than onFailure.
+        Settings settings = Settings.builder()
+            .put("prometheus.indices", true)
+            .put("prometheus.cluster.settings", false)
+            .build();
+        TransportNodePrometheusMetricsAction action = createAction(settings);
+
+        ActionListener<NodePrometheusMetricsResponse> outerListener = mock(ActionListener.class);
+        action.doExecute(task, new NodePrometheusMetricsRequest(), outerListener);
+
+        completeClusterHealthAndNodesInfo();
+
+        ArgumentCaptor<ActionListener<NodesStatsResponse>> statsCaptor = ArgumentCaptor.forClass(ActionListener.class);
+        verify(clusterAdminClient).nodesStats(any(), statsCaptor.capture());
+        NodesStatsResponse statsResponse = mock(NodesStatsResponse.class);
+        when(statsResponse.getNodes()).thenReturn(Collections.emptyList());
+        statsCaptor.getValue().onResponse(statsResponse);
+
+        ArgumentCaptor<ActionListener<IndicesStatsResponse>> indicesCaptor = ArgumentCaptor.forClass(ActionListener.class);
+        verify(indicesAdminClient).stats(any(IndicesStatsRequest.class), indicesCaptor.capture());
+        indicesCaptor.getValue().onFailure(new RuntimeException("no such index [test]"));
+
+        verify(outerListener).onFailure(any());
+        verify(outerListener, never()).onResponse(any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void indicesStatsRequest_hasTimeoutAndCancelOnTimeout() {
+        Settings settings = Settings.builder()
+            .put("prometheus.indices", true)
+            .put("prometheus.cluster.settings", false)
+            .put("prometheus.scrape.step_timeout", "5s")
+            .build();
+        TransportNodePrometheusMetricsAction action = createAction(settings);
+
+        ActionListener<NodePrometheusMetricsResponse> outerListener = mock(ActionListener.class);
+        action.doExecute(task, new NodePrometheusMetricsRequest(), outerListener);
+
+        completeClusterHealthAndNodesInfo();
+
+        ArgumentCaptor<ActionListener<NodesStatsResponse>> statsCaptor = ArgumentCaptor.forClass(ActionListener.class);
+        verify(clusterAdminClient).nodesStats(any(), statsCaptor.capture());
+        NodesStatsResponse statsResponse = mock(NodesStatsResponse.class);
+        when(statsResponse.getNodes()).thenReturn(Collections.emptyList());
+        statsCaptor.getValue().onResponse(statsResponse);
+
+        ArgumentCaptor<IndicesStatsRequest> requestCaptor = ArgumentCaptor.forClass(IndicesStatsRequest.class);
+        verify(indicesAdminClient).stats(requestCaptor.capture(), any());
+
+        IndicesStatsRequest capturedRequest = requestCaptor.getValue();
+        assertEquals(TimeValue.timeValueSeconds(5), capturedRequest.timeout());
+        assertTrue(capturedRequest.getShouldCancelOnTimeout());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void nodesStatsTotalFailure_propagatesAsFailure() {
+        // As with IndicesStats, a total NodesStats failure propagates. A single unresponsive node does not
+        // reach here: TransportNodesAction records it as a per-node FailedNodeException and still completes
+        // via onResponse with partial results, bounded by the per-node request timeout.
+        Settings settings = Settings.builder()
+            .put("prometheus.indices", false)
+            .put("prometheus.cluster.settings", false)
+            .build();
+        TransportNodePrometheusMetricsAction action = createAction(settings);
+
+        ActionListener<NodePrometheusMetricsResponse> outerListener = mock(ActionListener.class);
+        action.doExecute(task, new NodePrometheusMetricsRequest(), outerListener);
+
+        completeClusterHealthAndNodesInfo();
+
+        ArgumentCaptor<ActionListener<NodesStatsResponse>> statsCaptor = ArgumentCaptor.forClass(ActionListener.class);
+        verify(clusterAdminClient).nodesStats(any(), statsCaptor.capture());
+        statsCaptor.getValue().onFailure(new RuntimeException("simulated total failure"));
+
+        verify(outerListener).onFailure(any());
+        verify(outerListener, never()).onResponse(any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void nodesStatsRequest_hasTimeout() {
+        Settings settings = Settings.builder()
+            .put("prometheus.indices", false)
+            .put("prometheus.cluster.settings", false)
+            .put("prometheus.scrape.step_timeout", "7s")
+            .build();
+        TransportNodePrometheusMetricsAction action = createAction(settings);
+
+        ActionListener<NodePrometheusMetricsResponse> outerListener = mock(ActionListener.class);
+        action.doExecute(task, new NodePrometheusMetricsRequest(), outerListener);
+
+        completeClusterHealthAndNodesInfo();
+
+        ArgumentCaptor<NodesStatsRequest> requestCaptor = ArgumentCaptor.forClass(NodesStatsRequest.class);
+        verify(clusterAdminClient).nodesStats(requestCaptor.capture(), any());
+
+        assertEquals(TimeValue.timeValueSeconds(7), requestCaptor.getValue().timeout());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void scrapeStepTimeout_defaultsToFiveSeconds() {
+        Settings settings = Settings.builder()
+            .put("prometheus.indices", false)
+            .put("prometheus.cluster.settings", false)
+            .build();
+        TransportNodePrometheusMetricsAction action = createAction(settings);
+
+        ActionListener<NodePrometheusMetricsResponse> outerListener = mock(ActionListener.class);
+        action.doExecute(task, new NodePrometheusMetricsRequest(), outerListener);
+
+        completeClusterHealthAndNodesInfo();
+
+        ArgumentCaptor<NodesStatsRequest> requestCaptor = ArgumentCaptor.forClass(NodesStatsRequest.class);
+        verify(clusterAdminClient).nodesStats(requestCaptor.capture(), any());
+
+        assertEquals(TimeValue.timeValueSeconds(5), requestCaptor.getValue().timeout());
+    }
+}


### PR DESCRIPTION
### Description
TransportNodePrometheusMetricsAction gathers a scrape by issuing several requests in sequence, two of which (NodesStatsRequest, IndicesStatsRequest) fan out to every node in the cluster. Neither request had a timeout, and a failure on either one failed the whole scrape. As a result, a single node that stops responding (for example one stuck in an uninterruptible I/O wait after a disk failure) can stall metrics collection on every node in the cluster indefinitely, since every node's scrape depends on the same cluster-wide fan-out.

During an incident where a node's disk was slow, all metrics went dark, because every fan-out request was hanging waiting on that node.

- Add a new dynamic setting, prometheus.scrape.step_timeout (default 5s), and apply it to both NodesStatsRequest and IndicesStatsRequest.
- IndicesStatsRequest additionally sets setShouldCancelOnTimeout(true), which actively cancels child tasks on a stuck node once the deadline fires, rather than just abandoning the response.
- Make failures on these two requests non-fatal: log a warning and return a partial response (empty node stats / null indices stats) instead of failing the whole scrape. The other steps in the chain (cluster health, local node info) never leave the local node, so they cannot be stalled by a remote node and are left as fatal-on-failure, since there is no meaningful partial result to fall back to.

Adds unit tests covering the timeout configuration and the non-fatal degrade path for both requests.
### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-prometheus-exporter/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).