### PR TITLE
Expose cluster.max_shards_per_node as a Prometheus metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This plugin was started as a fork of the Prometheus exporter for Elasticsearch®
     - File System
     - Circuit Breaker
 - Indices status
-- Cluster settings (notably [disk watermarks](https://docs.opensearch.org/latest/install-and-configure/configuring-opensearch/cluster-settings/#cluster-level-routing-and-allocation-settings) that can be updated dynamically)
+- Cluster settings (notably [disk watermarks](https://docs.opensearch.org/latest/install-and-configure/configuring-opensearch/cluster-settings/#cluster-level-routing-and-allocation-settings) and the [maximum number of shards per node](https://docs.opensearch.org/latest/install-and-configure/configuring-opensearch/cluster-settings/#cluster-level-shard-block-and-task-settings) that can be updated dynamically)
 
 ## Compatibility Matrix
 

--- a/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java
+++ b/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java
@@ -902,6 +902,8 @@ public class PrometheusMetricsCollector {
         catalog.registerClusterGauge("cluster_routing_allocation_disk_watermark_low_pct", "Low watermark for disk usage in pct");
         catalog.registerClusterGauge("cluster_routing_allocation_disk_watermark_high_pct", "High watermark for disk usage in pct");
         catalog.registerClusterGauge("cluster_routing_allocation_disk_watermark_flood_stage_pct", "Flood stage watermark for disk usage in pct");
+        //
+        catalog.registerClusterGauge("cluster_max_shards_per_node", "Maximum number of primary and replica shards allowed per node");
     }
 
     @SuppressWarnings({"checkstyle:LineLength", "checkstyle:LeftCurly"})
@@ -919,6 +921,8 @@ public class PrometheusMetricsCollector {
             if (stats.getDiskLowInPct() != null) { catalog.setClusterGauge("cluster_routing_allocation_disk_watermark_low_pct", stats.getDiskLowInPct()); }
             if (stats.getDiskHighInPct() != null) { catalog.setClusterGauge("cluster_routing_allocation_disk_watermark_high_pct", stats.getDiskHighInPct()); }
             if (stats.getFloodStageInPct() != null) { catalog.setClusterGauge("cluster_routing_allocation_disk_watermark_flood_stage_pct", stats.getFloodStageInPct()); }
+            //
+            if (stats.getMaxShardsPerNode() != null) { catalog.setClusterGauge("cluster_max_shards_per_node", stats.getMaxShardsPerNode()); }
         }
     }
 

--- a/src/main/java/org/opensearch/action/ClusterStatsData.java
+++ b/src/main/java/org/opensearch/action/ClusterStatsData.java
@@ -20,6 +20,7 @@ import static org.opensearch.cluster.routing.allocation.DiskThresholdSettings.CL
 import static org.opensearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING;
 import static org.opensearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING;
 import static org.opensearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING;
+import static org.opensearch.indices.ShardLimitValidator.SETTING_CLUSTER_MAX_SHARDS_PER_NODE;
 
 import org.opensearch.OpenSearchParseException;
 import org.opensearch.action.admin.cluster.state.ClusterStateResponse;
@@ -51,6 +52,12 @@ import java.io.IOException;
  * To make it easy for Prometheus to consume the data, we expose these settings in both formats (pct and bytes)
  * and we do our best in determining if they are currently set as pct or bytes filling appropriate variables
  * with data or null value.
+ * <p>
+ * On top of the disk watermarks we expose the cluster-wide shard limit ("cluster.max_shards_per_node" [3]),
+ * which makes it possible to alert on a cluster approaching the maximum number of shards it can host.
+ * <ul>
+ *   <li> [3] <a href="https://docs.opensearch.org/latest/install-and-configure/configuring-opensearch/cluster-settings/">Cluster Settings ("cluster.max_shards_per_node")</a></li>
+ * </ul>
  */
 public class ClusterStatsData extends ActionResponse {
 
@@ -63,6 +70,8 @@ public class ClusterStatsData extends ActionResponse {
     @Nullable private final Double diskLowInPct;
     @Nullable private final Double diskHighInPct;
     @Nullable private final Double floodStageInPct;
+
+    @Nullable private final Long maxShardsPerNode;
 
     /**
      * A constructor.
@@ -80,6 +89,8 @@ public class ClusterStatsData extends ActionResponse {
         diskLowInPct = in.readOptionalDouble();
         diskHighInPct = in.readOptionalDouble();
         floodStageInPct = in.readOptionalDouble();
+        //
+        maxShardsPerNode = in.readOptionalLong();
     }
 
     @SuppressWarnings({"checkstyle:LineLength"})
@@ -94,6 +105,7 @@ public class ClusterStatsData extends ActionResponse {
         Double resolvedDiskLowInPct = null;
         Double resolvedDiskHighInPct = null;
         Double resolvedFloodStageInPct = null;
+        Long resolvedMaxShardsPerNode = null;
 
         // There are several layers of cluster settings in OpenSearch each having different priority.
         // We need to traverse them from the top priority down to find relevant value of each setting.
@@ -125,6 +137,11 @@ public class ClusterStatsData extends ActionResponse {
                     CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING.getKey());
             resolvedFloodStageInBytes = firstNonNull(resolvedFloodStageInBytes, parsedFlood.bytes());
             resolvedFloodStageInPct = firstNonNull(resolvedFloodStageInPct, parsedFlood.pct());
+
+            if (resolvedMaxShardsPerNode == null) {
+                resolvedMaxShardsPerNode = currentSettings.getAsLong(
+                        SETTING_CLUSTER_MAX_SHARDS_PER_NODE.getKey(), null);
+            }
         }
 
         thresholdEnabled = resolvedThresholdEnabled;
@@ -134,6 +151,7 @@ public class ClusterStatsData extends ActionResponse {
         diskLowInPct = resolvedDiskLowInPct;
         diskHighInPct = resolvedDiskHighInPct;
         floodStageInPct = resolvedFloodStageInPct;
+        maxShardsPerNode = resolvedMaxShardsPerNode;
     }
 
     private record LongValue(@Nullable Long bytes, @Nullable Double pct) {
@@ -177,6 +195,8 @@ public class ClusterStatsData extends ActionResponse {
         out.writeOptionalDouble(diskLowInPct);
         out.writeOptionalDouble(diskHighInPct);
         out.writeOptionalDouble(floodStageInPct);
+        //
+        out.writeOptionalLong(maxShardsPerNode);
     }
 
     /**
@@ -240,5 +260,14 @@ public class ClusterStatsData extends ActionResponse {
     @Nullable
     public Double getFloodStageInPct() {
         return floodStageInPct;
+    }
+
+    /**
+     * Get value of setting controlled by {@link org.opensearch.indices.ShardLimitValidator#SETTING_CLUSTER_MAX_SHARDS_PER_NODE}.
+     * @return A Long value of the setting.
+     */
+    @Nullable
+    public Long getMaxShardsPerNode() {
+        return maxShardsPerNode;
     }
 }

--- a/src/yamlRestTest/resources/rest-api-spec/test/40_40_cluster_settings_max_shards_per_node.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/40_40_cluster_settings_max_shards_per_node.yml
@@ -1,0 +1,161 @@
+---
+"Cluster settings statistics: max shards per node":
+
+  # -----------------------------------
+  # By default "cluster.max_shards_per_node" setting is set to '1000'.
+  # See: org.opensearch.indices.ShardLimitValidator
+  # OOTB there are no transient or persistent settings in the cluster, which means
+  # the value is resolved from the cluster defaults:
+  # (note: no "flat_settings" here, we want to traverse the nested response
+  #  to reach the default value of the setting)
+  - do:
+      cluster.get_settings:
+        include_defaults: true
+
+  - match: {persistent: {}}
+  - match: {transient: {}}
+  - match: {defaults.cluster.max_shards_per_node: "1000"}
+
+  # Verify in Prometheus metrics:
+  - do:
+      prometheus.metrics: {}
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s opensearch_cluster_max_shards_per_node (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_max_shards_per_node \s gauge \n
+        opensearch_cluster_max_shards_per_node\{
+            cluster="yamlRestTest"
+        \,} \s 1000\.0 \n?
+        .*/
+
+  # -----------------------------------
+  # Lower the shard limit at the PERSISTENT level:
+  - do:
+      cluster.put_settings:
+        body:
+          persistent:
+            cluster.max_shards_per_node: 500
+        flat_settings: true
+
+  - match: {persistent: {cluster.max_shards_per_node: "500"}}
+
+  - do:
+      cluster.get_settings:
+        flat_settings: true
+
+  - match: {transient: {}}
+  - match: {persistent: {cluster.max_shards_per_node: "500"}}
+
+  # Verify in Prometheus metrics:
+  - do:
+      prometheus.metrics: {}
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s opensearch_cluster_max_shards_per_node (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_max_shards_per_node \s gauge \n
+        opensearch_cluster_max_shards_per_node\{
+            cluster="yamlRestTest"
+        \,} \s 500\.0 \n?
+        .*/
+
+  # -----------------------------------
+  # The TRANSIENT level takes precedence over the PERSISTENT one:
+  - do:
+      cluster.put_settings:
+        body:
+          transient:
+            cluster.max_shards_per_node: 200
+        flat_settings: true
+
+  - match: {transient: {cluster.max_shards_per_node: "200"}}
+
+  - do:
+      cluster.get_settings:
+        flat_settings: true
+
+  - match: {transient: {cluster.max_shards_per_node: "200"}}
+  - match: {persistent: {cluster.max_shards_per_node: "500"}}
+
+  # Verify in Prometheus metrics:
+  - do:
+      prometheus.metrics: {}
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s opensearch_cluster_max_shards_per_node (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_max_shards_per_node \s gauge \n
+        opensearch_cluster_max_shards_per_node\{
+            cluster="yamlRestTest"
+        \,} \s 200\.0 \n?
+        .*/
+
+  # -----------------------------------
+  # Wipe out the setting at the PERSISTENT level. There is still an override
+  # at the TRANSIENT (ie. higher) level:
+  - do:
+      cluster.put_settings:
+        body:
+          persistent:
+            cluster.max_shards_per_node: null
+        flat_settings: true
+
+  - match: {persistent: {}}
+
+  - do:
+      cluster.get_settings:
+        flat_settings: true
+
+  - match: {transient: {cluster.max_shards_per_node: "200"}}
+  - match: {persistent: {}}
+
+  # Verify in Prometheus metrics:
+  - do:
+      prometheus.metrics: {}
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s opensearch_cluster_max_shards_per_node (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_max_shards_per_node \s gauge \n
+        opensearch_cluster_max_shards_per_node\{
+            cluster="yamlRestTest"
+        \,} \s 200\.0 \n?
+        .*/
+
+  # -----------------------------------
+  # Finally, wipe out the setting from the TRANSIENT level as well.
+  # We are back to the cluster default value:
+  - do:
+      cluster.put_settings:
+        body:
+          transient:
+            cluster.max_shards_per_node: null
+        flat_settings: true
+
+  - match: {transient: {}}
+
+  - do:
+      cluster.get_settings:
+        flat_settings: true
+
+  - match: {transient: {}}
+  - match: {persistent: {}}
+
+  # Verify in Prometheus metrics:
+  - do:
+      prometheus.metrics: {}
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s opensearch_cluster_max_shards_per_node (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_max_shards_per_node \s gauge \n
+        opensearch_cluster_max_shards_per_node\{
+            cluster="yamlRestTest"
+        \,} \s 1000\.0 \n?
+        .*/


### PR DESCRIPTION
### Description

Exposes the `cluster.max_shards_per_node` cluster setting as a new Prometheus gauge, so that operators can alert on a cluster approaching its configured shard capacity:

```
# HELP opensearch_cluster_max_shards_per_node Maximum number of primary and replica shards allowed per node
# TYPE opensearch_cluster_max_shards_per_node gauge
opensearch_cluster_max_shards_per_node{cluster="opensearch",} 1000.0
```

Combined with the metrics that already exist, this makes the shard-capacity alert the issue asks for expressible:

```
opensearch_cluster_shards_number{type="active"}
  / (opensearch_cluster_max_shards_per_node * opensearch_cluster_datanodes_number)
  > 0.9
```

### Implementation notes

The value is read in `ClusterStatsData` using the same layered lookup already used for the disk watermark settings — transient → persistent → cluster defaults. Because `ClusterSettings#diff` fills in the declared default for any registered setting that is not explicitly set, the gauge reports the built-in default (`1000`) on an otherwise untouched cluster rather than going missing, which follows the [avoid missing metrics](https://prometheus.io/docs/practices/instrumentation/#avoid-missing-metrics) guidance the existing tests cite.

The setting is a plain integer, so none of the pct/bytes ambiguity handling that the watermark settings need applies here.

### Issues Resolved

Closes #513

### Testing

Added `40_40_cluster_settings_max_shards_per_node.yml`, which mirrors the structure of the existing `40_10` disk threshold test: it asserts the default value, then an override at the persistent level, then at the transient level, then verifies the transient level takes precedence when the persistent one is removed, and finally that removing both returns the metric to the cluster default.

### A note on ownership

I see #513 is assigned to @RamyaSaba. This PR is not meant to step on that — I had the change written and tested before noticing, and I am happy to close it if @RamyaSaba is still working on the issue or would prefer to submit their own version. Please just say the word.

### Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.
